### PR TITLE
fix webhook verification for Java

### DIFF
--- a/dist/doc/payments/webhooks/verifying-transaction.js
+++ b/dist/doc/payments/webhooks/verifying-transaction.js
@@ -63,7 +63,7 @@ public class HMacExample {
     Mac sha512_HMAC = Mac.getInstance(HMAC_SHA512);      
     sha512_HMAC.init(keySpec);
     byte [] mac_data = sha512_HMAC.
-    doFinal(body.toString().getBytes("UTF-8"));
+    doFinal(body.getBytes("UTF-8"));
     result = DatatypeConverter.printHexBinary(mac_data);
     if(result.toLowerCase().equals(xpaystackSignature)) {
       // you can trust the event, it came from paystack

--- a/src/doc/payments/webhooks/verifying-transaction/index.java
+++ b/src/doc/payments/webhooks/verifying-transaction/index.java
@@ -27,7 +27,7 @@ public class HMacExample {
     Mac sha512_HMAC = Mac.getInstance(HMAC_SHA512);      
     sha512_HMAC.init(keySpec);
     byte [] mac_data = sha512_HMAC.
-    doFinal(body.toString().getBytes("UTF-8"));
+    doFinal(body.getBytes("UTF-8"));
     result = DatatypeConverter.printHexBinary(mac_data);
     if(result.toLowerCase().equals(xpaystackSignature)) {
       // you can trust the event, it came from paystack


### PR DESCRIPTION
The `toString()` method sorts the JSON object alphabetically which causes the verification to fail.